### PR TITLE
Update to 0.12.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "jedi" %}
-{% set version = "0.12.0" %}
-{% set sha256 = "1972f694c6bc66a2fac8718299e2ab73011d653a6d8059790c3476d2353b99ad" %}
+{% set version = "0.12.1" %}
+{% set sha256 = "b409ed0f6913a701ed474a614a3bb46e6953639033e31f769ca7581da5bd1ec1" %}
 
 package:
   name: {{ name|lower }}
@@ -14,7 +14,7 @@ source:
     - ff4a77391a3920d2d1547213cb34a9aef8fbaf79.patch
 
 build:
-  number: 1
+  number: 0
   script: {{PYTHON}} setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:
@@ -24,7 +24,7 @@ requirements:
 
   run:
     - python
-    - parso >=0.2.0
+    - parso >=0.3.0
 
 test:
   imports:


### PR DESCRIPTION
@nehaljwani, @jjhelmus, @mingwandroid, you update `parso` to `0.3.0` on Friday (I think), but that's incompatible with the current version of Jedi (`0.12.0`). Hence this update is necessary.

Without this, code completions are broken in Spyder's editor (detected by our tests during the weekend).