### PR TITLE
Update `Jedi` to version `0.18.1`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,9 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
+  # the minimal version of python supported is 3.6 
+  # https://github.com/davidhalter/jedi/blob/v0.18.1/setup.py#L34
+  skip: true  # [py<36]
 
 requirements:
   # # we don't currently use this for cross-compiling.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,7 +52,7 @@ about:
     well. Jedi is fast and is very well tested. It understands Python on a
     deeper level than all other static analysis frameworks for Python.
   dev_url: https://github.com/davidhalter/jedi/
-  doc_url: http://jedi.readthedocs.io/en/latest/
+  doc_url: https://jedi.readthedocs.io/en/latest/
   doc_source_url: https://github.com/davidhalter/jedi/blob/master/docs/index.rst
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 74137626a64a99c8eb6ae5832d99b3bdd7d29a3850fe2aa80a4126b2a7d949ab
 
 build:
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -20,6 +20,8 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
     - parso >=0.8.0,<0.9.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,15 +11,11 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
-  # the minimal version of python supported is 3.6 
-  # https://github.com/davidhalter/jedi/blob/v0.18.1/setup.py#L34
+  # the minimal version of python supported is 3.6
   skip: true  # [py<36]
 
 requirements:
-  # # we don't currently use this for cross-compiling.
-  # build:
-  #   - python                                 # [build_platform != target_platform]
-  #   - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+  # # we don't currently use cross-compiling.
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.18.0" %}
+{% set version = "0.18.1" %}
 
 package:
   name: jedi
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/j/jedi/jedi-{{ version }}.tar.gz
-  sha256: 92550a404bad8afed881a137ec9a461fed49eca661414be45059329614ed0707
+  sha256: 74137626a64a99c8eb6ae5832d99b3bdd7d29a3850fe2aa80a4126b2a7d949ab
 
 build:
   number: 1


### PR DESCRIPTION

  `jedi` version `0.18.1`
1. - [x] check the upstream
    https://github.com/davidhalter/jedi/tree/v0.18.1

2. - [x] check the pinnings
    https://github.com/davidhalter/jedi/blob/v0.18.1/setup.py

    https://github.com/davidhalter/jedi/blob/v0.18.1/setup.cfg

    minimal version of `python` required is `3.6`
    https://github.com/davidhalter/jedi/blob/v0.18.1/setup.py#L34

3. - [x] check the changelogs
    https://github.com/davidhalter/jedi/blob/v0.18.1/CHANGELOG.rst

    The changes mentioned in the changelog were mainly bug fixes, there was added for `Python` version `3.10`

4. - [x] additional research
    https://github.com/conda-forge/jedi-feedstock/issues

    There is one open issue mentioned in the recipe with one of the dependencies `parso`, however the issue seems to have been resolved

    https://github.com/conda-forge/jedi-feedstock/issues/34

5. - [x] verify dev_url
    https://github.com/davidhalter/jedi/

6. - [x] verify doc_url
    http://jedi.readthedocs.io/en/latest/

7. - [x] license is spdx compliant
    https://spdx.org/licenses/MIT.html
8. - [x] license family
    https://spdx.org/licenses/MIT.html
9. - [x] verify the build number
    the build number was reset to zero
10. - [x] verify setuptools
    added setuptools to the recipe
11. - [x] verify wheel
    added wheels to the recipe
12. - [x] pip in the test section
    pip is in the test section
13. - [x] veriy the test section
    the test section was verified

Results:
- All Passed


Based on the research findings and the results we can conclude
that it is safe to update `jedi` to version `0.18.1`
