### PR TITLE
jedi 0.18.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.18.1" %}
+{% set version = "0.18.2" %}
 
 package:
   name: jedi
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/j/jedi/jedi-{{ version }}.tar.gz
-  sha256: 74137626a64a99c8eb6ae5832d99b3bdd7d29a3850fe2aa80a4126b2a7d949ab
+  sha256: bae794c30d07f6d910d32a7048af09b5a39ed740918da923c6b780790ebac612
 
 build:
   number: 1


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index 22b153f..29cd2bc 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.18.1" %}
+{% set version = "0.18.2" %}
 
 package:
   name: jedi
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/j/jedi/jedi-{{ version }}.tar.gz
-  sha256: 74137626a64a99c8eb6ae5832d99b3bdd7d29a3850fe2aa80a4126b2a7d949ab
+  sha256: bae794c30d07f6d910d32a7048af09b5a39ed740918da923c6b780790ebac612
 
 build:
   number: 1

```

**Jira ticket:** []() (-)

**The upstream data:**
Github releases:  https://github.com/davidhalter/jedi//releases
[Diff between the latest and previous upstream releases](https://github.com/davidhalter/jedi//compare/0.18.1...0.18.2)
License: https://github.com/davidhalter/jedi//blob/master/LICENSE.txt
Changelog: https://github.com/davidhalter/jedi//blob/master/CHANGELOG.rst
Requirements:
 * setup.cfg:  https://github.com/davidhalter/jedi//blob/v0.18.2/setup.cfg
 * setup.py:  https://github.com/davidhalter/jedi//blob/v0.18.2/setup.py

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority C | effort: easy | Category: anaconda | subcategory: dependency | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-s390x', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 0.18.2
 * Release on PyPi:
    * version: 0.18.2
    * date: 2022-11-21T22:32:59
* [PyPi history](https://pypi.org/project/jedi/#history)
 * Popularity: 
    * 3 months downloads: 2367174.0
    * All time:  14243846 downloads -  jedi  0.18.2  An autocompletion tool for Python that can be used for text editors.  

</details>

**Other checks:**

<details>

1. - [ ] Check the pinnings
2. - [ ] Verify that the `build_number` is correct
3. - [x] has `setuptools`
5. - [x] has `wheel`
8. - [ ] NO `pip` in test
    python
9. - [ ] Verify the test section
10. - [ ] Verify if the package is `architecture specific`
11. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
12.  - [x] license_file: LICENSE.txt is present

14. - [x] license_family MIT is present
16. - [x] License: MIT
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier         |
|:-------------------|
| MIT                |
| MIT-0              |
| MIT-advertising    |
| MIT-CMU            |
| MIT-enna           |
| MIT-feh            |
| MIT-Modern-Variant |
| MIT-open-group     |
| MITNFA             |
</details>

**Check dependency issues:**

<details>
../aggregate/jedi-feedstock/recipe/meta.yaml
Dependencies: ['wheel', 'setuptools', 'python', 'pip', 'parso >=0.8.0,<0.9.0']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 19**


</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/jedi-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/jedi-feedstock/tree/0.18.2)
* [conda-forge recipe](https://github.com/conda-forge/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/jedi)
* [Diff between upstream and feature branch](https://github.com/conda-forge/jedi-feedstock/compare/main...AnacondaRecipes:0.18.2)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/jedi-feedstock/compare/master...AnacondaRecipes:0.18.2)
* [The last merged PRs](https://github.com/AnacondaRecipes/jedi-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 0.18.2 git@github.com:AnacondaRecipes/jedi-feedstock.git
```
