### PR TITLE
jedi 0.19.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,21 +1,21 @@
-{% set version = "0.18.1" %}
+{% set name = "jedi" %}
+{% set version = "0.19.1" %}
 
 package:
-  name: jedi
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/j/jedi/jedi-{{ version }}.tar.gz
-  sha256: 74137626a64a99c8eb6ae5832d99b3bdd7d29a3850fe2aa80a4126b2a7d949ab
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: cf0496f3651bc65d7174ac1b7d043eff454892c708a87d1b683e57b569927ffd
 
 build:
-  number: 1
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
   # the minimal version of python supported is 3.6
   skip: true  # [py<36]
 
 requirements:
-  # # we don't currently use cross-compiling.
   host:
     - python
     - pip
@@ -23,11 +23,9 @@ requirements:
     - wheel
   run:
     - python
-    - parso >=0.8.0,<0.9.0
+    - parso >=0.8.3,<0.9.0
 
 test:
-  requires:
-    - pip
   imports:
     - jedi
     - jedi.api
@@ -38,8 +36,10 @@ test:
     - jedi.inference.gradual
     - jedi.inference.value
     - jedi.plugins
+  requires:
+    - pip
   commands:
-    - python -m pip check
+    - pip check
 
 about:
   home: https://github.com/davidhalter/jedi/
@@ -53,8 +53,7 @@ about:
     well. Jedi is fast and is very well tested. It understands Python on a
     deeper level than all other static analysis frameworks for Python.
   dev_url: https://github.com/davidhalter/jedi/
-  doc_url: https://jedi.readthedocs.io/en/latest/
-  doc_source_url: https://github.com/davidhalter/jedi/blob/master/docs/index.rst
+  doc_url: https://jedi.readthedocs.io/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-5266](https://anaconda.atlassian.net/browse/PKG-5266) 
- [Upstream repository](https://github.com/davidhalter/jedi/tree/v0.19.1)
- Changelog: https://github.com/davidhalter/jedi/blob/v0.19.1/CHANGELOG.rst
- Requirements: https://github.com/davidhalter/jedi/blob/v0.19.1/setup.py

### Explanation of changes:

- Clean up the recipe
- Update runtime pinning


[PKG-5266]: https://anaconda.atlassian.net/browse/PKG-5266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ